### PR TITLE
BUGFIX: config preserved in BlockManager

### DIFF
--- a/code/BlockManager.php
+++ b/code/BlockManager.php
@@ -38,7 +38,7 @@ class BlockManager extends Object{
 
 		if(count($areas)){
 			foreach ($areas as $k => $v) {
-				$areas[$k] = FormField::name_to_label($k);
+				$areas[$k] = $keyAsValue ? FormField::name_to_label($k) : $v;
 			}	
 		}
 		return $areas;


### PR DESCRIPTION
Config was being overwritten with labels, so "except", "only" etc weren't being respected.
