### PR TITLE
Sort blocks by FIELD(Area) so they appear in order as declaration

### DIFF
--- a/code/extensions/BlocksSiteTreeExtension.php
+++ b/code/extensions/BlocksSiteTreeExtension.php
@@ -45,7 +45,12 @@ class BlocksSiteTreeExtension extends SiteTreeExtension{
 				->addBulkEditing();
 
 			//$gridSource = $this->getBlockList(null, false);
-			$gridSource = $this->owner->Blocks();
+			$gridSource = $this->owner->Blocks()
+				// sort by FIELD Area to force the same order as areas are declared in config
+				->sort(array(
+					"FIELD(Area, '".implode("','",array_keys($areas))."')" => '', 
+					'Weight'=>'ASC', 'Title' => 'ASC'
+				));
 			$fields->addFieldToTab('Root.Blocks', GridField::create('Blocks', 'Blocks', $gridSource, $gridConfig));
 			
 			// Blocks inherited from SiteConfig and BlockSets


### PR DESCRIPTION
Sort the blocks on pages in the order the block-areas are declared in the config.yml instead of alphabetical (eg 'Header, BeforeContent, Aftercontent, Footer')
