### PR TITLE
Updated for newer releases of dependent modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
 		"composer/installers": "*",
 		"silverstripe/framework": "3.1.*",
 		"silverstripe/cms": "3.1.*",
-		"silverstripe-australia/gridfieldextensions": "1.0.*",
-		"silverstripe/multivaluefield": "2.0.*",
-		"unclecheese/betterbuttons": "~1.2.0"
+		"silverstripe-australia/gridfieldextensions": "~1.0",
+		"silverstripe/multivaluefield": "~2.0",
+		"unclecheese/betterbuttons": "~1.2"
 	},
 	"suggest": {
 		"unisolutions/silverstripe-copybutton": "Duplicate Blocks in Block Admin",


### PR DESCRIPTION
Have used ~syntax so that any later minor version will be usable by the module too