### PR TITLE
NEW Allow a blockset to be bound to parent node

### DIFF
--- a/code/dataobjects/BlockSet.php
+++ b/code/dataobjects/BlockSet.php
@@ -11,7 +11,8 @@ class BlockSet extends DataObject implements PermissionProvider{
 	 **/
 	private static $db = array(
 		'Title' => 'Varchar(255)',
-		'PageTypes' => 'MultiValueField'
+		'PageTypes' => 'MultiValueField',
+		'IncludePageParent'	=> 'Boolean',
 	);
 
 	/**
@@ -51,6 +52,7 @@ class BlockSet extends DataObject implements PermissionProvider{
 		$fields->addFieldToTab('Root.Main', MultiValueCheckboxField::create('PageTypes', 'Only apply to these Page Types:', $this->pageTypeOptions())
 				->setDescription('Selected Page Types will inherit this Block Set automatically. Leave all unchecked to apply to all page types.'));
 		$fields->addFieldToTab('Root.Main', TreeMultiselectField::create('PageParents', 'Only apply to children of these Pages:', 'SiteTree'));
+		$fields->addFieldToTab('Root.Main', CheckboxField::create('IncludePageParent', 'Apply block set to selected page parents as well as children'));
 
 		if(!$this->ID){
 			$fields->addFieldToTab('Root.Main', LiteralField::create('NotSaved', "<p class='message warning'>You can add Blocks to this set once you have saved it for the first time</p>"));

--- a/code/extensions/BlocksSiteTreeExtension.php
+++ b/code/extensions/BlocksSiteTreeExtension.php
@@ -195,11 +195,20 @@ class BlocksSiteTreeExtension extends SiteTreeExtension {
 
 		foreach ($sets as $set) {
 			$restrictedToParerentIDs = $set->PageParents()->column('ID');
-			if (count($restrictedToParerentIDs) && count($ancestors)) {
-				foreach ($ancestors as $ancestor) {
-					if (in_array($ancestor, $restrictedToParerentIDs)) {
-						$list->add($set);
-						continue;
+			if (count($restrictedToParerentIDs)) {
+				// check whether the set should include selected parent, in which case check whether 
+				// it was in the restricted parents list. If it's not, or if include parentpage 
+				// wasn't selected, we check the ancestors of this page. 
+				if ($set->IncludePageParent && in_array($this->owner->ID, $restrictedToParerentIDs)) {
+					$list->add($set);
+				} else {
+					if (count($ancestors)) {
+						foreach ($ancestors as $ancestor) {
+							if (in_array($ancestor, $restrictedToParerentIDs)) {
+								$list->add($set);
+								continue;
+							}
+						}
 					}
 				}
 			} else {


### PR DESCRIPTION
Adds an option that, if selected, allows a blockset to be bound on the selected
node from the tree instead of just the _child_ nodes of the selected item.
Addresses issue #34