### PR TITLE
Accept include_from_page_type config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ BlockManager:
 
       use_blocksets: false # Whether to use BlockSet functionality (default if undeclared: true)
       use_extra_css_classes: true # Whether to allow cms users to add extra css classes to blocks (default if undeclared: false)
-      exclude_from_page_types: # Disable the Blocks tab completely on these pages of these types 
-        - ContactPage 
+      include_from_page_types: # Enable the Blocks tab on these pages of these types
+        - HomePage
+      exclude_from_page_types: # Disable the Blocks tab completely on these pages of these types (can not use with include_from_page_type at the same time, otherwise, only based on include_from_page_type)
+        - ContactPage
   use_default_blocks: false # Disable/enable the default Block types (ContentBlock) (default if undeclared: true)
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ BlockManager:
 
       use_blocksets: false # Whether to use BlockSet functionality (default if undeclared: true)
       use_extra_css_classes: true # Whether to allow cms users to add extra css classes to blocks (default if undeclared: false)
-      include_from_page_types: # Enable the Blocks tab on these pages of these types
+      pagetype_whitelist: # Enable the Blocks tab on these pages of these types
         - HomePage
-      exclude_from_page_types: # Disable the Blocks tab completely on these pages of these types (can not use with include_from_page_type at the same time, otherwise, only based on include_from_page_type)
+      exclude_from_page_types: # Disable the Blocks tab completely on these pages of these types (can not use with pagetype_whitelist at the same time, otherwise, only based on pagetype_whitelist)
         - ContactPage
   use_default_blocks: false # Disable/enable the default Block types (ContentBlock) (default if undeclared: true)
 ```

--- a/code/BlockManager.php
+++ b/code/BlockManager.php
@@ -158,6 +158,14 @@ class BlockManager extends Object{
 		return isset($config['include_from_page_types']) ? $config['include_from_page_types'] : array();
 	}
 
+    /*
+	 * Exclusion of blocks from page types defined in yaml
+	 */
+    public function getExcludeFromPageTypes(){
+        $config = $this->getThemeConfig();
+        return isset($config['exclude_from_page_types']) ? $config['exclude_from_page_types'] : array();
+    }
+
 	/*
 	 * Usage of extra css classes configurable from yaml
 	 */

--- a/code/BlockManager.php
+++ b/code/BlockManager.php
@@ -151,11 +151,11 @@ class BlockManager extends Object{
 	}
 
 	/*
-	 * Exclusion of blocks from page types defined in yaml
+	 * Inclusion of blocks from page types defined in yaml
 	 */
-	public function getExcludeFromPageTypes(){
+	public function getIncludeFromPageTypes(){
 		$config = $this->getThemeConfig();
-		return isset($config['exclude_from_page_types']) ? $config['exclude_from_page_types'] : array();
+		return isset($config['include_from_page_types']) ? $config['include_from_page_types'] : array();
 	}
 
 	/*

--- a/code/BlockManager.php
+++ b/code/BlockManager.php
@@ -155,16 +155,16 @@ class BlockManager extends Object{
 	 */
 	public function getIncludeFromPageTypes(){
 		$config = $this->getThemeConfig();
-		return isset($config['include_from_page_types']) ? $config['include_from_page_types'] : array();
+		return isset($config['pagetype_whitelist']) ? $config['pagetype_whitelist'] : array();
 	}
 
-    /*
+    	/*
 	 * Exclusion of blocks from page types defined in yaml
 	 */
-    public function getExcludeFromPageTypes(){
-        $config = $this->getThemeConfig();
-        return isset($config['exclude_from_page_types']) ? $config['exclude_from_page_types'] : array();
-    }
+    	public function getExcludeFromPageTypes(){
+        	$config = $this->getThemeConfig();
+        	return isset($config['exclude_from_page_types']) ? $config['exclude_from_page_types'] : array();
+    	}
 
 	/*
 	 * Usage of extra css classes configurable from yaml

--- a/code/extensions/BlocksSiteTreeExtension.php
+++ b/code/extensions/BlocksSiteTreeExtension.php
@@ -32,7 +32,7 @@ class BlocksSiteTreeExtension extends SiteTreeExtension {
 	 * Block manager for Pages
 	 * */
 	public function updateCMSFields(FieldList $fields) {
-		if($fields->fieldByName('Root.Blocks') || in_array($this->owner->ClassName, $this->blockManager->getExcludeFromPageTypes()) || !$this->owner->exists()){
+		if($fields->fieldByName('Root.Blocks') || !$this->owner->exists()){
 			return;
 		}
 		
@@ -40,63 +40,68 @@ class BlocksSiteTreeExtension extends SiteTreeExtension {
 			return;
 		}
 
-		$areas = $this->blockManager->getAreasForPageType($this->owner->ClassName);
+        if (in_array($this->owner->ClassName, $this->blockManager->getIncludeFromPageTypes())){
 
-		if ($areas && count($areas)) {
-			$fields->addFieldToTab('Root.Blocks', 
-					LiteralField::create('PreviewLink', $this->areasPreviewButton()));
+            $areas = $this->blockManager->getAreasForPageType($this->owner->ClassName);
 
-			// Blocks related directly to this Page 
-			$gridConfig = GridFieldConfig_BlockManager::create(true, true, true, true)
-				->addExisting($this->owner->class)
-				//->addBulkEditing()
-				->addComponent(new GridFieldOrderableRows())
-				;
+            if ($areas && count($areas)) {
+                $fields->addFieldToTab('Root.Blocks',
+                        LiteralField::create('PreviewLink', $this->areasPreviewButton()));
 
-			// TODO it seems this sort is not being applied...
-			$gridSource = $this->owner->Blocks();
-				// ->sort(array(
-				// 	"FIELD(SiteTree_Blocks.BlockArea, '" . implode("','", array_keys($areas)) . "')" => '',
-				// 	'SiteTree_Blocks.Sort' => 'ASC', 
-				// 	'Name' => 'ASC'
-				// ));
+                // Blocks related directly to this Page
+                $gridConfig = GridFieldConfig_BlockManager::create(true, true, true, true)
+                    ->addExisting($this->owner->class)
+                    //->addBulkEditing()
+                    ->addComponent(new GridFieldOrderableRows())
+                    ;
 
-			$fields->addFieldToTab('Root.Blocks', GridField::create('Blocks', 'Blocks', $gridSource, $gridConfig));
+                // TODO it seems this sort is not being applied...
+                $gridSource = $this->owner->Blocks();
+                    // ->sort(array(
+                    // 	"FIELD(SiteTree_Blocks.BlockArea, '" . implode("','", array_keys($areas)) . "')" => '',
+                    // 	'SiteTree_Blocks.Sort' => 'ASC',
+                    // 	'Name' => 'ASC'
+                    // ));
+
+                $fields->addFieldToTab('Root.Blocks', GridField::create('Blocks', 'Blocks', $gridSource, $gridConfig));
 
 
-			// Blocks inherited from BlockSets
-			if ($this->blockManager->getUseBlockSets()) {
-				$inheritedBlocks = $this->getBlocksFromAppliedBlockSets(null, true);
-			
-				if ($inheritedBlocks->count()) {
-					$activeInherited = $this->getBlocksFromAppliedBlockSets(null, false);
+                // Blocks inherited from BlockSets
+                if ($this->blockManager->getUseBlockSets()) {
+                    $inheritedBlocks = $this->getBlocksFromAppliedBlockSets(null, true);
 
-					if ($activeInherited->count()) {
-						$fields->addFieldsToTab('Root.Blocks', array(
-							GridField::create('InheritedBlockList', 'Blocks Inherited from Block Sets', $activeInherited, 
-								GridFieldConfig_BlockManager::create(false, false, false)),
-							LiteralField::create('InheritedBlockListTip', "<p class='message'>Tip: Inherited blocks can be edited in the <a href='admin/block-admin'>Block Admin area</a><p>")
-						));
-					}
+                    if ($inheritedBlocks->count()) {
+                        $activeInherited = $this->getBlocksFromAppliedBlockSets(null, false);
 
-					$fields->addFieldToTab('Root.Blocks', 
-							ListBoxField::create('DisabledBlocks', 'Disable Inherited Blocks', 
-									$inheritedBlocks->map('ID', 'Title'), null, null, true)
-									->setDescription('Select any inherited blocks that you would not like displayed on this page.')
-					);
-				} else {
-					$fields->addFieldToTab('Root.Blocks', 
-							ReadonlyField::create('DisabledBlocksReadOnly', 'Disable Inherited Blocks', 
-									'This page has no inherited blocks to disable.'));
-				}
+                        if ($activeInherited->count()) {
+                            $fields->addFieldsToTab('Root.Blocks', array(
+                                GridField::create('InheritedBlockList', 'Blocks Inherited from Block Sets', $activeInherited,
+                                    GridFieldConfig_BlockManager::create(false, false, false)),
+                                LiteralField::create('InheritedBlockListTip', "<p class='message'>Tip: Inherited blocks can be edited in the <a href='admin/block-admin'>Block Admin area</a><p>")
+                            ));
+                        }
 
-				$fields->addFieldToTab('Root.Blocks', 
-					CheckboxField::create('InheritBlockSets', 'Inherit Blocks from Block Sets'));
-			}
-			
-		} else {
-			$fields->addFieldToTab('Root.Blocks', LiteralField::create('Blocks', 'This page type has no Block Areas configured.'));
-		}
+                        $fields->addFieldToTab('Root.Blocks',
+                                ListBoxField::create('DisabledBlocks', 'Disable Inherited Blocks',
+                                        $inheritedBlocks->map('ID', 'Title'), null, null, true)
+                                        ->setDescription('Select any inherited blocks that you would not like displayed on this page.')
+                        );
+                    } else {
+                        $fields->addFieldToTab('Root.Blocks',
+                                ReadonlyField::create('DisabledBlocksReadOnly', 'Disable Inherited Blocks',
+                                        'This page has no inherited blocks to disable.'));
+                    }
+
+                    $fields->addFieldToTab('Root.Blocks',
+                        CheckboxField::create('InheritBlockSets', 'Inherit Blocks from Block Sets'));
+                }
+
+            } else {
+                $fields->addFieldToTab('Root.Blocks', LiteralField::create('Blocks', 'This page type has no Block Areas configured.'));
+            }
+        }else{
+            return;
+        }
 	}
 
 

--- a/code/extensions/BlocksSiteTreeExtension.php
+++ b/code/extensions/BlocksSiteTreeExtension.php
@@ -32,7 +32,7 @@ class BlocksSiteTreeExtension extends SiteTreeExtension {
 	 * Block manager for Pages
 	 * */
 	public function updateCMSFields(FieldList $fields) {
-		if($fields->fieldByName('Root.Blocks') || !$this->owner->exists()){
+		if($fields->fieldByName('Root.Blocks') || in_array($this->owner->ClassName, $this->blockManager->getExcludeFromPageTypes()) || !$this->owner->exists()){
 			return;
 		}
 		
@@ -40,7 +40,7 @@ class BlocksSiteTreeExtension extends SiteTreeExtension {
 			return;
 		}
 
-        if (in_array($this->owner->ClassName, $this->blockManager->getIncludeFromPageTypes())){
+        if (!$this->blockManager->getIncludeFromPageTypes() || in_array($this->owner->ClassName, $this->blockManager->getIncludeFromPageTypes())){
 
             $areas = $this->blockManager->getAreasForPageType($this->owner->ClassName);
 


### PR DESCRIPTION
In my case, I want to apply this module on one page type only. But there are many page types in my code base. I do not want to list them one by one in the exclude_from_page_type setting. So I added the include_from_page_type to make it flexible in different situations. 