### PR TITLE
ENH: add config setting to prefix the default CSSClasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Blocks modules aims to provide developers with a flexible foundation for def
 #### Composer
 
 	composer require sheadawson/silverstripe-blocks
-	
+
 Install via composer, run dev/build
 
 ## Quickstart
@@ -58,8 +58,9 @@ BlockManager:
 
       use_blocksets: false # Whether to use BlockSet functionality (default if undeclared: true)
       use_extra_css_classes: true # Whether to allow cms users to add extra css classes to blocks (default if undeclared: false)
-      exclude_from_page_types: # Disable the Blocks tab completely on these pages of these types 
-        - ContactPage 
+      prefix_default_css_classes: 'myprefix--' # prefix the automatically generated CSSClasses based on class name (default if undeclared: false)
+      exclude_from_page_types: # Disable the Blocks tab completely on these pages of these types
+        - ContactPage
   use_default_blocks: false # Disable/enable the default Block types (ContentBlock) (default if undeclared: true)
 ```
 
@@ -92,7 +93,7 @@ You can limit a block area to a maximum number of blocks using the second limit 
 
 You will now be able to add Blocks to Pages via the CMS page edit view and in the Blocks model admin. You can also define "BlockSets" in the Blocks model admin. BlockSets can be used to apply a common collection of blocks to pages that match the criteria you define on the set.
 
-This module ships with a basic "ContentBlock", but this can be disabled through the BlockManager::use_default_blocks config. 
+This module ships with a basic "ContentBlock", but this can be disabled through the BlockManager::use_default_blocks config.
 
 #### Restrict Blocks to viewer groups or logged in users
 
@@ -100,13 +101,13 @@ When editing a block, you can restrict who can see it in the frontend by selecti
 
 ### Templates
 
-There are 2 types of templates you should be aware of. 
+There are 2 types of templates you should be aware of.
 
 #### BlockArea Template
 
-The BlockArea template is responsible for looping over and rendering all blocks in that area. You can override this by creating a copy of the default BlockArea.ss and placing it in your theme's templates/Includes folder. 
+The BlockArea template is responsible for looping over and rendering all blocks in that area. You can override this by creating a copy of the default BlockArea.ss and placing it in your theme's templates/Includes folder.
 
-It's likely that your block areas may require different templates. You can achieve this by creating a BlockArea_{AreaName}.ss template. 
+It's likely that your block areas may require different templates. You can achieve this by creating a BlockArea_{AreaName}.ss template.
 
 #### Block Template
 
@@ -114,7 +115,7 @@ Each subclass of Block requires it's own template with the same name as the clas
 
 ### Block Area Preview
 
-To aid website admins in identifying the areas they can apply blocks to, a "Preview Block Areas for this page" button is available in the cms. This opens the frontend view of the page in a new tab with ?block_preview=1. In Block Preview mode, Block Areas in the template are highlighted and labeled. 
+To aid website admins in identifying the areas they can apply blocks to, a "Preview Block Areas for this page" button is available in the cms. This opens the frontend view of the page in a new tab with ?block_preview=1. In Block Preview mode, Block Areas in the template are highlighted and labeled.
 
 There is some markup required in your BlockArea templates to facilitate this: The css class "block-area" and the data-areaid='$AreaID' attribute.
 

--- a/code/BlockManager.php
+++ b/code/BlockManager.php
@@ -24,7 +24,7 @@ class BlockManager extends Object{
 		parent::__construct();
 	}
 
-	
+
 	/**
 	 * Gets an array of all areas defined for the current theme
 	 * @param string $theme
@@ -45,10 +45,10 @@ class BlockManager extends Object{
 		if(count($areas)){
 			foreach ($areas as $k => $v) {
 				$areas[$k] = $keyAsValue ? FormField::name_to_label($k) : $v;
-			}	
+			}
 		}
 		return $areas;
-		
+
 	}
 
 
@@ -92,7 +92,7 @@ class BlockManager extends Object{
 				}
 			}
 		}
-		
+
 		if(count($areas)){
 			foreach ($areas as $k => $v) {
 				$areas[$k] = FormField::name_to_label($k);
@@ -141,7 +141,7 @@ class BlockManager extends Object{
 		$config = $this->config()->get('themes');
 		return $theme && isset($config[$theme]) ? $config[$theme] : null;
 	}
-	
+
 	/*
 	 * Usage of BlockSets configurable from yaml
 	 */
@@ -164,6 +164,14 @@ class BlockManager extends Object{
 	public function getUseExtraCSSClasses(){
 		$config = $this->getThemeConfig();
 		return isset($config['use_extra_css_classes']) ? $config['use_extra_css_classes'] : false;
+	}
+
+	/*
+	 * Prefix for the default CSSClasses
+	 */
+	public function getPrefixDefaultCSSClasses() {
+		$config = $this->getThemeConfig();
+		return isset($config['prefix_default_css_classes']) ? $config['prefix_default_css_classes'] : false;
 	}
 
 }

--- a/code/dataobjects/Block.php
+++ b/code/dataobjects/Block.php
@@ -67,13 +67,13 @@ class Block extends DataObject implements PermissionProvider{
 
 	public function getCMSFields(){
 		Requirements::add_i18n_javascript(BLOCKS_DIR . '/javascript/lang');
-		
+
 		// this line is a temporary patch until I can work out why this dependency isn't being
 		// loaded in some cases...
 		if(!$this->blockManager) $this->blockManager = singleton('BlockManager');
 
 		$fields = parent::getCMSFields();
-		
+
 		// ClassNmae - block type/class field
 		$classes = $this->blockManager->getBlockClasses();
 		$fields->addFieldToTab('Root.Main', DropdownField::create('ClassName', 'Block Type', $classes)->addExtraClass('block-type'), 'Title');
@@ -97,9 +97,9 @@ class Block extends DataObject implements PermissionProvider{
 		$fields->removeByName('Weight');
 		$fields->removeByName('Area');
 		$fields->removeByName('Published');
-	
+
 		if($this->blockManager->getUseExtraCSSClasses()){
-			$fields->addFieldToTab('Root.Main', $fields->dataFieldByName('ExtraCSSClasses'), 'Title');	
+			$fields->addFieldToTab('Root.Main', $fields->dataFieldByName('ExtraCSSClasses'), 'Title');
 		}else{
 			$fields->removeByName('ExtraCSSClasses');
 		}
@@ -109,14 +109,14 @@ class Block extends DataObject implements PermissionProvider{
 		$groupsMap = Group::get()->map('ID', 'Breadcrumbs')->toArray();
 		asort($groupsMap);
 		$viewersOptionsField = new OptionsetField(
-			"CanViewType", 
+			"CanViewType",
 			_t('SiteTree.ACCESSHEADER', "Who can view this page?")
 		);
 		$viewerGroupsField = ListboxField::create("ViewerGroups", _t('SiteTree.VIEWERGROUPS', "Viewer Groups"))
 			->setMultiple(true)
 			->setSource($groupsMap)
 			->setAttribute(
-				'data-placeholder', 
+				'data-placeholder',
 				_t('SiteTree.GroupPlaceholder', 'Click to select group')
 		);
 		$viewersOptionsSource = array();
@@ -129,28 +129,28 @@ class Block extends DataObject implements PermissionProvider{
 			$viewersOptionsField,
 			$viewerGroupsField,
 		));
-		
+
 		// Disabled for now, until we can list ALL pages this block is applied to (inc via sets)
 		// As otherwise it could be misleading
 		// Show a GridField (list only) with pages which this block is used on
 		// $fields->removeFieldFromTab('Root.Pages', 'Pages');
-		// $fields->addFieldsToTab('Root.Pages', 
+		// $fields->addFieldsToTab('Root.Pages',
 		// 		new GridField(
-		// 				'Pages', 
-		// 				'Used on pages', 
-		// 				$this->Pages(), 
+		// 				'Pages',
+		// 				'Used on pages',
+		// 				$this->Pages(),
 		// 				$gconf = GridFieldConfig_Base::create()));
 		// enhance gridfield with edit links to pages if GFEditSiteTreeItemButtons is available
-		// a GFRecordEditor (default) combined with BetterButtons already gives the possibility to 
-		// edit versioned records (Pages), but STbutton loads them in their own interface instead 
+		// a GFRecordEditor (default) combined with BetterButtons already gives the possibility to
+		// edit versioned records (Pages), but STbutton loads them in their own interface instead
 		// of GFdetailform
 		// if(class_exists('GridFieldEditSiteTreeItemButton')){
 		// 	$gconf->addComponent(new GridFieldEditSiteTreeItemButton());
 		// }
 
 		return $fields;
-		
-		
+
+
 	}
 
 
@@ -169,7 +169,7 @@ class Block extends DataObject implements PermissionProvider{
 
 	/**
 	 * Renders this block with appropriate templates
-	 * looks for templates that match BlockClassName_AreaName 
+	 * looks for templates that match BlockClassName_AreaName
 	 * falls back to BlockClassName
 	 * @return string
 	 **/
@@ -192,8 +192,8 @@ class Block extends DataObject implements PermissionProvider{
 		return $this->forTemplate();
 	}
 
-	
-	/* 
+
+	/*
 	 * Checks if deletion was an actual deletion, not just unpublish
 	 * If so, remove relations
 	 */
@@ -201,7 +201,7 @@ class Block extends DataObject implements PermissionProvider{
 		parent::onAfterDelete();
 		if (Versioned::current_stage() == 'Stage') {
 			$this->Pages()->removeAll();
-			$this->BlockSets()->removeAll();	
+			$this->BlockSets()->removeAll();
 		}
 	}
 
@@ -215,8 +215,8 @@ class Block extends DataObject implements PermissionProvider{
 		$this->BlockSets()->removeAll();
     }
 
-	
-	/* 
+
+	/*
 	 * Base permissions
 	 */
 	public function canView($member = null){
@@ -242,9 +242,9 @@ class Block extends DataObject implements PermissionProvider{
 		// check for specific groups
 		if($member && is_numeric($member)) $member = DataObject::get_by_id('Member', $member);
 		if($this->CanViewType == 'OnlyTheseUsers' && $member && $member->inGroups($this->ViewerGroups())){
-			return true;	
-		} 
-		
+			return true;
+		}
+
 		return false;
 	}
 
@@ -301,14 +301,14 @@ class Block extends DataObject implements PermissionProvider{
         }
         return $urls;
     }
-	
+
 	/*
 	 * Get a list of Page and Blockset titles this block is used on
 	 */
 	public function UsageListAsString() {
 		$pages = implode(", ", $this->Pages()->column('URLSegment'));
 		$sets = implode(", ", $this->BlockSets()->column('Title'));
-		if($pages && $sets) return "Pages: $pages<br />Block Sets: $sets";	
+		if($pages && $sets) return "Pages: $pages<br />Block Sets: $sets";
 		if($pages) return "Pages: $pages";
 		if($sets) return "Block Sets: $sets";
 	}
@@ -344,8 +344,13 @@ class Block extends DataObject implements PermissionProvider{
      */
     public function CSSClasses($stopAtClass = 'DataObject') {
 		$classes = strtolower(parent::CSSClasses($stopAtClass));
+
+		if( !empty($classes) && ($prefix = $this->blockManager->getPrefixDefaultCSSClasses())) {
+			$classes = $prefix . str_replace(" ", " {$prefix}", $classes);
+		}
+
 		if($this->blockManager->getUseExtraCSSClasses()){
-			$classes = $this->ExtraCSSClasses ? $classes . " $this->ExtraCSSClasses" : $classes;	
+			$classes = $this->ExtraCSSClasses ? $classes . " $this->ExtraCSSClasses" : $classes;
 		}
 		return $classes;
 	}


### PR DESCRIPTION
Allows for a config setting of prefix_default_css_classes i.e. 'myprefix--' which will change the CSSClasses output of the ContentBlock from 'contentblock block' to 'myprefix--contentblock myprefix--block'

This doesn't prefix the classes manually added in the ExtraCSSClasses field