### PR TITLE
allow disabling specific blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Blocks modules aims to provide developers with a flexible foundation for def
 * Block lists show "Used on" column, displaying Pages/Sets the Block is used on
 * Allow exclusion of any page types from using Blocks
 * Allow disabling of default/example block type - ContentBlock
+* Allow disabling of specific blocks
 * CMS Interfaces generally tidied up
 
 ### Upgrading from 0.x
@@ -61,6 +62,8 @@ BlockManager:
       prefix_default_css_classes: 'myprefix--' # prefix the automatically generated CSSClasses based on class name (default if undeclared: false)
       exclude_from_page_types: # Disable the Blocks tab completely on these pages of these types
         - ContactPage
+      #disabled_blocks: #allows you to disable specific blocks
+      #  - ContentBlock
   use_default_blocks: false # Disable/enable the default Block types (ContentBlock) (default if undeclared: true)
 ```
 

--- a/code/BlockManager.php
+++ b/code/BlockManager.php
@@ -115,6 +115,12 @@ class BlockManager extends Object{
 			unset($classes['ContentBlock']);
 		}
 
+        if($disabledArr = Config::inst()->get('BlockManager', 'disabled_blocks')){
+            foreach ($disabledArr as $k => $v) {
+                unset($classes[$v]);
+            }
+        }
+
 		return $classes;
 	}
 


### PR DESCRIPTION
I'd like to use a base class for shared functionality which I don't want the end user to be seeing.
Additionally this could also be useful for creating libraries of blocks, and allowing you to cherry pick blocks on a project basis.