### PR TITLE
FIX: Missing argument 1 for DataExtension::canEdit() 

### DIFF
--- a/code/extensions/BlockContentControllerExtension.php
+++ b/code/extensions/BlockContentControllerExtension.php
@@ -9,7 +9,7 @@ class BlocksContentControllerExtension extends Extension {
 	);
 
 	public function onAfterInit(){
-		if($this->owner->canEdit() && $this->owner->getRequest()->getVar('block_preview') == 1){
+		if($this->owner->canEdit(Member::currentUser()) && $this->owner->getRequest()->getVar('block_preview') == 1){
 			Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
 			Requirements::javascript(BLOCKS_DIR . '/javascript/block-preview.js');
 			Requirements::css(BLOCKS_DIR . '/css/block-preview.css');
@@ -19,7 +19,7 @@ class BlocksContentControllerExtension extends Extension {
 	/**
 	 * Handles blocks attached to a page
 	 * Assumes URLs in the following format: <URLSegment>/block/<block-ID>.
-	 * 
+	 *
 	 * @return RequestHandler
 	 */
 	public function handleBlock() {


### PR DESCRIPTION
During upgrading this module to support CWP 1.2.0 basic recipe and silverstripe framework 3.2.1, I found an error in with canEdit in the extension. this fixes it.