### PR TITLE
Add a config file option to remove the CMSMenu button. The option's…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ BlockManager:
       #disabled_blocks: #allows you to disable specific blocks
       #  - ContentBlock
   use_default_blocks: false # Disable/enable the default Block types (ContentBlock) (default if undeclared: true)
+  add_menu_button: true # If true, adds a 'Blocks' button to the main CMS menu. Default: true.
 ```
 
 Remember to run ?flush=1 after modifying your .yml config to make sure it gets applied.

--- a/_config.php
+++ b/_config.php
@@ -6,3 +6,5 @@ if (!defined('BLOCKS_DIR')) {
 
 Config::inst()->update('LeftAndMain', 'extra_requirements_javascript', array(BLOCKS_DIR.'/javascript/blocks-cms.js'));
 Config::inst()->update('BlockAdmin', 'menu_icon', BLOCKS_DIR.'/images/blocks.png');
+
+if (!BlockManager::config()->add_menu_button) CMSMenu::remove_menu_item('BlockAdmin');

--- a/code/BlockManager.php
+++ b/code/BlockManager.php
@@ -20,6 +20,13 @@ class BlockManager extends Object
      **/
     private static $use_default_blocks = true;
 
+    /**
+     * If true, adds a 'Blocks' button to the main CMS menu.
+     *
+     * @var bool
+     */
+    private static $add_menu_button = true;
+
     public function __construct()
     {
         parent::__construct();


### PR DESCRIPTION
…name is 'add_menu_button' and the default value is true so it does not change the current behavior when upgrading.