### PR TITLE
Block Type Filter

### DIFF
--- a/code/controllers/BlockAdmin.php
+++ b/code/controllers/BlockAdmin.php
@@ -57,4 +57,18 @@ class BlockAdmin extends ModelAdmin
 
         return $form;
     }
+
+    public function getSearchContext()
+    {
+        $context = parent::getSearchContext();
+        $fields = $context->getFields();
+        $subclasses = $this->blockManager->getBlockClasses();
+        if (sizeof($subclasses) > 1) {
+            $fields->dataFieldByName('q[ClassName]')->setSource($subclasses);
+            $fields->dataFieldByName('q[ClassName]')->setEmptyString('(any)');
+        } else {
+            $fields->removeByName('q[ClassName]');
+        }
+        return $context;
+    }
 }

--- a/code/dataobjects/Block.php
+++ b/code/dataobjects/Block.php
@@ -42,6 +42,28 @@ class Block extends DataObject implements PermissionProvider
         'UsageListAsString' => 'Used on',
     );
 
+    private static $searchable_fields = array(
+        'Title' => array(
+            'title' => 'Title'
+        ),
+        'ClassName' => array(
+            'title' => 'Block Type'
+        )
+    );
+
+    public function getDefaultSearchContext()
+    {
+        $context = parent::getDefaultSearchContext();
+        $results = $this->blockManager->getBlockClasses();
+        if (sizeof($results) > 1) {
+            $classfield = new DropdownField('ClassName', 'Block Type');
+            $classfield->setSource($results);
+            $classfield->setEmptyString('(any)');
+            $context->addField($classfield);
+        }
+        return $context;
+    }
+
     /**
      * @var array
      */


### PR DESCRIPTION
If more than one block type is defined, add a dropdown filter for Block Type.  If only one type defined (default Content block or any other), do not show the type filter.