### PR TITLE
Bug fix to Block Filters: couldn't use Block Set model admin

### DIFF
--- a/code/controllers/BlockAdmin.php
+++ b/code/controllers/BlockAdmin.php
@@ -63,7 +63,7 @@ class BlockAdmin extends ModelAdmin
         $context = parent::getSearchContext();
         $fields = $context->getFields();
         $subclasses = $this->blockManager->getBlockClasses();
-        if (sizeof($subclasses) > 1) {
+        if ($fields->dataFieldByName('q[ClassName]') && sizeof($subclasses) > 1) {
             $fields->dataFieldByName('q[ClassName]')->setSource($subclasses);
             $fields->dataFieldByName('q[ClassName]')->setEmptyString('(any)');
         } else {


### PR DESCRIPTION
Since BlockSet didn't have q[ClassName] in it's fields, we got a 500 error whenever visiting that page.  Adding a simple check for this field before trying to setSource seems to solve the issue.