### PR TITLE
fixing breaks in gridfield

### DIFF
--- a/code/forms/GridfieldConfig_BlockManager.php
+++ b/code/forms/GridfieldConfig_BlockManager.php
@@ -39,7 +39,7 @@ class GridFieldConfig_BlockManager extends GridFieldConfig
                         },
                 ),
                 'isPublishedNice' => array('title' => _t('Block.IsPublishedField', 'Published'), 'field' => 'ReadonlyField'),
-                'UsageListAsString' => array('title' => _t('Block.UsageListAsString', 'Used on'), 'field' => 'ReadonlyField'),
+                'UsageListAsString' => array('title' => _t('Block.UsageListAsString', 'Used on'), 'field' => 'LiteralField'),
             );
 
             if ($aboveOrBelow) {


### PR DESCRIPTION
This fixes `<br>`s appearing in gridfield, see screenshots.

## before
![screenshot 2016-04-14 11 28 47](https://cloud.githubusercontent.com/assets/1316533/14523512/65d5d292-0234-11e6-8f53-5b2d2598edf3.png)

## after
![screenshot 2016-04-14 11 29 16](https://cloud.githubusercontent.com/assets/1316533/14523513/65f7f430-0234-11e6-9238-bb8d1dedc5e6.png)
