### PR TITLE
type for gridfield

### DIFF
--- a/code/dataobjects/Block.php
+++ b/code/dataobjects/Block.php
@@ -97,6 +97,14 @@ class Block extends DataObject implements PermissionProvider
      */
     protected $controller;
 
+    /**
+     * @return mixed
+     */
+    public function getTypeForGridfield()
+    {
+        return $this->singular_name();
+    }
+
     public function getCMSFields()
     {
         Requirements::add_i18n_javascript(BLOCKS_DIR.'/javascript/lang');

--- a/code/forms/GridfieldConfig_BlockManager.php
+++ b/code/forms/GridfieldConfig_BlockManager.php
@@ -27,7 +27,7 @@ class GridFieldConfig_BlockManager extends GridFieldConfig
         if ($editableRows) {
             $this->addComponent($editable = new GridFieldEditableColumns());
             $displayfields = array(
-                'singular_name' => array('title' => _t('Block.BlockType', 'Block Type'), 'field' => 'ReadonlyField'),
+                'TypeForGridfield' => array('title' => _t('Block.BlockType', 'Block Type'), 'field' => 'LiteralField'),
                 'Title' => array('title' => _t('Block.Title', 'Title'), 'field' => 'ReadonlyField'),
                 'BlockArea' => array(
                     'title' => _t('Block.BlockArea', 'Block Area').'


### PR DESCRIPTION
By having a getter for the type to be shown in GridField, it's easy to display there whatever you want.
Below is an example how I'm using it to display icons in my blocks.

![screenshot 2016-04-14 16 31 24](https://cloud.githubusercontent.com/assets/1316533/14531627/651f8670-025e-11e6-801e-ff7f6f8afafc.png)


```php
public function getFaIconClass()
{
    return null;
}

/**
 * @return string
 */
public function getIcon()
{
    $faClass = $this->getFaIconClass();
    if ($faClass) {
        return '<i class="fa ' . $faClass . ' fa-3x" title="' . $this->singular_name() . '" aria-hidden="true"></i>';
    }
}

/**
 * @return mixed
 */
public function getTypeForGridfield()
{
    $icon = $this->getIcon();
    if ($icon) {
        $obj = HTMLText::create();
        $obj->setValue($icon);
        return $obj;
    } else {
        return parent::getTypeForGridfield();
    }
}
```
