### PR TITLE
Hide blocks tab on non-blockable pages

### DIFF
--- a/code/extensions/BlocksSiteTreeExtension.php
+++ b/code/extensions/BlocksSiteTreeExtension.php
@@ -95,8 +95,6 @@ class BlocksSiteTreeExtension extends SiteTreeExtension
                 $fields->addFieldToTab('Root.Blocks',
                     CheckboxField::create('InheritBlockSets', _t('BlocksSiteTreeExtension.InheritBlocksFromBlockSets', 'Inherit Blocks from Block Sets')));
             }
-        } else {
-            $fields->addFieldToTab('Root.Blocks', LiteralField::create('Blocks', _t('BlocksSiteTreeExtension.NoBlockAreasConfigured', 'This page type has no Block Areas configured.')));
         }
     }
 


### PR DESCRIPTION
Initially this change was made at https://github.com/sheadawson/silverstripe-blocks/commit/0537a508b5403a1959c0b4239c9364678020ca29 but seemed to have slipped back in at https://github.com/sheadawson/silverstripe-blocks/commit/090c97f9bf9034a8fe8625df0bcff98b7d4800a8#diff-2c89ac4c8eba5b8a392fbe87a5dcd414R86.
I'm making this PR under the assumption the re-adding of this was accidental but if it was meant to be put back in, feel free to close this PR :)