### PR TITLE
FIX: use constant for framework folder reference in published icons

### DIFF
--- a/code/dataobjects/Block.php
+++ b/code/dataobjects/Block.php
@@ -419,9 +419,9 @@ class Block extends DataObject implements PermissionProvider
     {
         $obj = HTMLText::create();
         if ($this->isPublished()) {
-            $obj->setValue('<img src="/framework/admin/images/alert-good.gif" />');
+            $obj->setValue('<img src="' . FRAMEWORK_ADMIN_DIR . '/images/alert-good.gif" />');
         } else {
-            $obj->setValue('<img src="/framework/admin/images/alert-bad.gif" />');
+            $obj->setValue('<img src="' . FRAMEWORK_ADMIN_DIR . '/images/alert-bad.gif" />');
         }
         return $obj;
     }


### PR DESCRIPTION
* published icons did not display when SilverStripe installed in subfolder