### PR TITLE
FIX Content field label no longer overridden by Block

### DIFF
--- a/code/dataobjects/Block.php
+++ b/code/dataobjects/Block.php
@@ -57,7 +57,6 @@ class Block extends DataObject implements PermissionProvider
             'isPublishedField' => _t('Block.IsPublishedField', 'Published'),
             'UsageListAsString' => _t('Block.UsageListAsString', 'Used on'),
             'ExtraCSSClasses' => _t('Block.ExtraCSSClasses', 'Extra CSS Classes'),
-            'Content' => _t('Block.Content', 'Content'),
             'ClassName' => _t('Block.BlockType', 'Block Type'),
         ));
 

--- a/code/dataobjects/ContentBlock.php
+++ b/code/dataobjects/ContentBlock.php
@@ -25,4 +25,14 @@ class ContentBlock extends Block
     private static $db = array(
         'Content' => 'HTMLText',
     );
+
+	public function fieldLabels($includeRelations = true)
+	{
+		return array_merge(
+			parent::fieldLabels($includeRelations),
+			array(
+				'Content' => _t('Block.Content', 'Content'),
+			)
+		);
+	}
 }


### PR DESCRIPTION
Currently the `Block` overrides the `fieldLabel` for `Content` despite not actually defining a `Content` field (it's defined on `ContentBlock`, though).

This means extensions of `Block` can't override the `Content` `fieldLabel` using the config system if they also define a `Content` field.

This patch resolves this issue as it moves the overriding of `Content` `fieldLabel` onto `ContentBlock`