### PR TITLE
Issue #146 - Adding a defaultBlockArea

### DIFF
--- a/_config/blocks.yml
+++ b/_config/blocks.yml
@@ -17,6 +17,6 @@ SiteConfig:
     - BlockSiteConfigExtension
 
 Block:
+  defaultBlockArea: false
   extensions:
     - Versioned('Stage','Live')
-

--- a/code/dataobjects/Block.php
+++ b/code/dataobjects/Block.php
@@ -257,6 +257,16 @@ class Block extends DataObject implements PermissionProvider
         $this->BlockSets()->removeAll();
     }
 
+    public function onBeforeWrite()
+    {
+        $defaultBlockArea = Block::config()->get('defaultBlockArea');
+        $blockArea = $this->getField('ManyMany[BlockArea]');
+        if ($defaultBlockArea !== false && $blockArea === null) {
+            $this->setField('ManyMany[BlockArea]', $defaultBlockArea);
+        }
+        parent::onBeforeWrite();
+    }
+
     /*
      * Base permissions
      */


### PR DESCRIPTION
I remade this to fit v1.1 (which is what I am currently using) but no real reason why it should not work on master too? Fixes #146 

As per the other PR, this might be better as a SiteConfig setting so that people can set the default from the options available in the CMS. Let me know if you want to go down that path